### PR TITLE
Add state of the art voice bitrates

### DIFF
--- a/app/src/main/java/com/dimowner/audiorecorder/AppConstants.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/AppConstants.java
@@ -107,7 +107,8 @@ public class AppConstants {
 	public static final int RECORD_SAMPLE_RATE_32000 = 32000;
 	public static final int RECORD_SAMPLE_RATE_48000 = 48000;
 
-	public static final int RECORD_ENCODING_BITRATE_12000 = 12000; //Bitrate for 3gp format
+	public static final int RECORD_ENCODING_BITRATE_8000 = 8000;
+	public static final int RECORD_ENCODING_BITRATE_16000 = 16000;
 	public static final int RECORD_ENCODING_BITRATE_24000 = 24000;
 	public static final int RECORD_ENCODING_BITRATE_48000 = 48000;
 	public static final int RECORD_ENCODING_BITRATE_96000 = 96000;

--- a/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsActivity.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsActivity.java
@@ -186,9 +186,12 @@ public class SettingsActivity extends Activity implements SettingsContract.View,
 		sampleRateSetting.setOnInfoClickListener(v -> AndroidUtils.showInfoDialog(SettingsActivity.this, R.string.info_frequency));
 
 		bitrateSetting = findViewById(R.id.setting_bitrate);
+
+
 		rates = getResources().getStringArray(R.array.bit_rates2);
 		rateKeys = new String[] {
-//				SettingsMapper.BITRATE_24000,
+				SettingsMapper.BITRATE_8000,
+				SettingsMapper.BITRATE_16000,
 				SettingsMapper.BITRATE_48000,
 				SettingsMapper.BITRATE_96000,
 				SettingsMapper.BITRATE_128000,
@@ -196,6 +199,7 @@ public class SettingsActivity extends Activity implements SettingsContract.View,
 				SettingsMapper.BITRATE_256000,
 		};
 		bitrateSetting.setData(rates, rateKeys);
+
 		bitrateSetting.setOnChipCheckListener((key, name, checked) -> presenter.setSettingRecordingBitrate(SettingsMapper.keyToBitrate(key)));
 		bitrateSetting.setTitle(R.string.bitrate);
 		bitrateSetting.setOnInfoClickListener(v -> AndroidUtils.showInfoDialog(SettingsActivity.this, R.string.info_bitrate));
@@ -528,8 +532,14 @@ public class SettingsActivity extends Activity implements SettingsContract.View,
 		if (format.equals(AppConstants.FORMAT_3GP)) {
 			channelsSetting.removeChip(new String[] {SettingsMapper.CHANNEL_COUNT_STEREO});
 			channelsSetting.setSelected(SettingsMapper.CHANNEL_COUNT_MONO);
+			final String[] rates = getResources().getStringArray(R.array.bit_rates);
+			bitrateSetting.setData(rates, rateKeys);
+			bitrateSetting.setSelected(SettingsMapper.BITRATE_16000);
 		} else {
 			channelsSetting.addChip(new String[] {SettingsMapper.CHANNEL_COUNT_STEREO}, new String[] {getString(R.string.stereo)});
+			final String[] rates = getResources().getStringArray(R.array.bit_rates2);
+			bitrateSetting.setData(rates, rateKeys);
+			bitrateSetting.setSelected(SettingsMapper.BITRATE_48000);
 		}
 	}
 

--- a/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsMapper.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsMapper.java
@@ -254,8 +254,10 @@ public class SettingsMapper {
 
 	public static String bitrateToKey(int bitrate) {
 		switch (bitrate) {
-//			case AppConstants.RECORD_ENCODING_BITRATE_24000:
-//				return BITRATE_24000;
+			case AppConstants.RECORD_ENCODING_BITRATE_8000:
+				return BITRATE_8000;
+			case AppConstants.RECORD_ENCODING_BITRATE_16000:
+				return BITRATE_16000;
 			case AppConstants.RECORD_ENCODING_BITRATE_48000:
 				return BITRATE_48000;
 			case AppConstants.RECORD_ENCODING_BITRATE_96000:

--- a/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsMapper.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsMapper.java
@@ -58,8 +58,8 @@ public class SettingsMapper {
 	public final static String SAMPLE_RATE_44100 = "44100";
 	public final static String SAMPLE_RATE_48000 = "48000";
 
-	public final static String BITRATE_12000 = "12000";
-//	public final static String BITRATE_24000 = "24000";
+	public final static String BITRATE_8000 = "8000";
+	public final static String BITRATE_16000 = "16000";
 	public final static String BITRATE_48000 = "48000";
 	public final static String BITRATE_96000 = "96000";
 	public final static String BITRATE_128000 = "128000";
@@ -233,8 +233,10 @@ public class SettingsMapper {
 
 	public static int keyToBitrate(String bitrateKey) {
 		switch (bitrateKey) {
-//			case BITRATE_24000:
-//				return AppConstants.RECORD_ENCODING_BITRATE_24000;
+			case BITRATE_8000:
+				return AppConstants.RECORD_ENCODING_BITRATE_8000;
+			case BITRATE_16000:
+				return AppConstants.RECORD_ENCODING_BITRATE_16000;
 			case BITRATE_48000:
 				return AppConstants.RECORD_ENCODING_BITRATE_48000;
 			case BITRATE_96000:
@@ -252,8 +254,6 @@ public class SettingsMapper {
 
 	public static String bitrateToKey(int bitrate) {
 		switch (bitrate) {
-			case AppConstants.RECORD_ENCODING_BITRATE_12000:
-				return BITRATE_12000;
 //			case AppConstants.RECORD_ENCODING_BITRATE_24000:
 //				return BITRATE_24000;
 			case AppConstants.RECORD_ENCODING_BITRATE_48000:

--- a/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsPresenter.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/app/settings/SettingsPresenter.java
@@ -266,46 +266,32 @@ public class SettingsPresenter implements SettingsContract.UserActionsListener {
 		final long space = FileUtil.getFree(fileRepository.getRecordingDir());
 		String format = prefs.getSettingRecordingFormat();
 		int sampleRate = prefs.getSettingSampleRate();
+
+		int channelsCount = prefs.getSettingChannelCount();
 		if (format.equals(AppConstants.FORMAT_3GP)) {
-			if (view != null) {
-				view.showAvailableSpace(
-						TimeUtils.formatTimeIntervalHourMinSec(
-								spaceToTimeSecs(space, format, sampleRate,
-										AppConstants.RECORD_ENCODING_BITRATE_12000, AppConstants.RECORD_AUDIO_MONO)
-						)
-				);
-				view.showSizePerMin(
-						decimalFormat.format(
-								sizePerMin(format, sampleRate, AppConstants.RECORD_ENCODING_BITRATE_12000,
-										AppConstants.RECORD_AUDIO_MONO) / 1000000f
-						)
-				);
-				view.showInformation(settingsMapper.convertFormatsToString(format) + AppConstants.SEPARATOR
-						+ settingsMapper.convertSampleRateToString(sampleRate) + AppConstants.SEPARATOR
-						+ settingsMapper.formatBitrate(AppConstants.RECORD_ENCODING_BITRATE_12000 / 1000) + AppConstants.SEPARATOR
-						+ settingsMapper.convertChannelsToString(AppConstants.RECORD_AUDIO_MONO));
-			}
-		} else {
-			int bitrate = prefs.getSettingBitrate();
-			int channelsCount = prefs.getSettingChannelCount();
-			final long time = spaceToTimeSecs(space, format, sampleRate, bitrate, channelsCount);
-			if (view != null) {
-				view.showAvailableSpace(TimeUtils.formatTimeIntervalHourMinSec(time));
-				view.showSizePerMin(decimalFormat.format(sizePerMin(format, sampleRate, bitrate, channelsCount) / 1000000f));
-				switch (format) {
-					default:
-					case AppConstants.FORMAT_M4A:
-						view.showInformation(settingsMapper.convertFormatsToString(format) + AppConstants.SEPARATOR
-								+ settingsMapper.convertSampleRateToString(sampleRate) + AppConstants.SEPARATOR
-								+ settingsMapper.convertBitratesToString(bitrate) + AppConstants.SEPARATOR
-								+ settingsMapper.convertChannelsToString(channelsCount));
-						break;
-					case AppConstants.FORMAT_WAV:
-						view.showInformation(settingsMapper.convertFormatsToString(format) + AppConstants.SEPARATOR
-								+ settingsMapper.convertSampleRateToString(sampleRate) + AppConstants.SEPARATOR
-								+ settingsMapper.convertChannelsToString(channelsCount));
-						break;
-				}
+			channelsCount = 1;
+		}
+		int bitrate = prefs.getSettingBitrate();
+		if (format.equals(AppConstants.FORMAT_WAV)) {
+			bitrate = 1411 * channelsCount;
+		}
+		final long time = spaceToTimeSecs(space, format, sampleRate, bitrate, channelsCount);
+		if (view != null) {
+			view.showAvailableSpace(TimeUtils.formatTimeIntervalHourMinSec(time));
+			view.showSizePerMin(new DecimalFormat("#.##").format(sizePerMin(format, sampleRate, bitrate, channelsCount) / 1000000f));
+			switch (format) {
+				default:
+				case AppConstants.FORMAT_M4A:
+					view.showInformation(settingsMapper.convertFormatsToString(format) + AppConstants.SEPARATOR
+							+ settingsMapper.convertSampleRateToString(sampleRate) + AppConstants.SEPARATOR
+							+ settingsMapper.convertBitratesToString(bitrate) + AppConstants.SEPARATOR
+							+ settingsMapper.convertChannelsToString(channelsCount));
+					break;
+				case AppConstants.FORMAT_WAV:
+					view.showInformation(settingsMapper.convertFormatsToString(format) + AppConstants.SEPARATOR
+							+ settingsMapper.convertSampleRateToString(sampleRate) + AppConstants.SEPARATOR
+							+ settingsMapper.convertChannelsToString(channelsCount));
+					break;
 			}
 		}
 	}
@@ -337,9 +323,9 @@ public class SettingsPresenter implements SettingsContract.UserActionsListener {
 	private void updateRecordingFormat(String formatKey) {
 		switch (formatKey) {
 			case AppConstants.FORMAT_WAV:
-			case AppConstants.FORMAT_3GP:
 				view.hideBitrateSelector();
 				break;
+			case AppConstants.FORMAT_3GP:
 			case AppConstants.FORMAT_M4A:
 			default:
 				view.showBitrateSelector();

--- a/app/src/main/java/com/dimowner/audiorecorder/app/setup/SetupPresenter.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/app/setup/SetupPresenter.java
@@ -229,7 +229,7 @@ public class SetupPresenter implements SetupContract.UserActionsListener {
 		if (format.equals(AppConstants.FORMAT_3GP)) {
 			view.showSizePerMin(
 					decimalFormat.format(
-							sizePerMin(format, sampleRate, AppConstants.RECORD_ENCODING_BITRATE_12000,
+							sizePerMin(format, sampleRate, AppConstants.RECORD_ENCODING_BITRATE_16000,
 									AppConstants.RECORD_AUDIO_MONO) / 1000000f
 					)
 			);

--- a/app/src/main/java/com/dimowner/audiorecorder/audio/recorder/ThreeGpRecorder.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/audio/recorder/ThreeGpRecorder.java
@@ -70,11 +70,8 @@ public class ThreeGpRecorder implements RecorderContract.Recorder {
 			recorder = new MediaRecorder();
 			recorder.setAudioSource(MediaRecorder.AudioSource.MIC);
 			recorder.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP);
-			if (sampleRate > 8000) {
-				recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_WB); //AMR_WR records with 16000 Hz frequency, ~23 kbps bitrate
-			} else {
-				recorder.setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB);  //AMR_NB records with 8000 Hz frequency, ~12 kbps bitrate
-			}
+			recorder.setAudioEncoder(sampleRate == 8000 ? MediaRecorder.AudioEncoder.AMR_NB : MediaRecorder.AudioEncoder.AMR_WB);
+			recorder.setAudioEncodingBitRate(bitrate);
 			recorder.setMaxDuration(-1); //Duration unlimited or use RECORD_MAX_DURATION
 			recorder.setOutputFile(recordFile.getAbsolutePath());
 			try {

--- a/app/src/main/java/com/dimowner/audiorecorder/data/FileRepositoryImpl.java
+++ b/app/src/main/java/com/dimowner/audiorecorder/data/FileRepositoryImpl.java
@@ -225,21 +225,11 @@ public class FileRepositoryImpl implements FileRepository {
 			space = FileUtil.getAvailableInternalMemorySize(context);
 		}
 
-		final long time = spaceToTimeSecs(space, prefs.getSettingRecordingFormat(),
-				prefs.getSettingSampleRate(), prefs.getSettingBitrate(), prefs.getSettingChannelCount());
+		final long time = spaceToTimeSecs(space, prefs.getSettingRecordingFormat(), prefs.getSettingBitrate(), prefs.getSettingChannelCount());
 		return time > AppConstants.MIN_REMAIN_RECORDING_TIME;
 	}
 
-	private long spaceToTimeSecs(long spaceBytes, String recordingFormat, int sampleRate, int bitrate, int channels) {
-		switch (recordingFormat) {
-			case AppConstants.FORMAT_3GP:
-				return 1000 * (spaceBytes/(AppConstants.RECORD_ENCODING_BITRATE_12000/8));
-			case AppConstants.FORMAT_M4A:
-				return 1000 * (spaceBytes/(bitrate/8));
-			case AppConstants.FORMAT_WAV:
-				return 1000 * (spaceBytes/(sampleRate * channels * 2));
-			default:
-				return 0;
-		}
+	private long spaceToTimeSecs(long spaceBytes, String recordingFormat, int bitrate, int channels) {
+		return 1000 * (spaceBytes/(bitrate/8));
 	}
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -261,8 +261,14 @@
 		<item>3gp</item>
 	</string-array>
 
+	<string-array name="bit_rates">
+		<item>8 kbps</item>
+		<item>16 kbps</item>
+	</string-array>
+
 	<string-array name="bit_rates2">
-<!--		<item>24 kbps</item>-->
+		<item>8 kbps</item>
+		<item>16 kbps</item>
 		<item>48 kbps</item>
 		<item>96 kbps</item>
 		<item>128 kbps</item>


### PR DESCRIPTION
the current state is one bit per samples. and preferably a cutoff at 8k is recommended to possible unload some work on the encoder. i will try to add opus too. users can record and compae. i am absolutely certain that 16 k is hte right bitrate. hey all we want is les bits right. 

i was going to add a volume mixer but i realized how much work it would be since i have t add a pcm recorder and live modify and encode it esentially recreaing the whole class just to fix my mic. i also have a feeling that the right volume can be selected. i have looked at this procedure in my mind;     1    check for voice in the sound. shouldnt be too heavey since google once used that ALL the time remembe hello hgoogle how could it possibly do that without fairies and magic if it did not sample for voice all the time    2  check the amplitute of the voice over a moving average   3  i record long doctors notes and someone has to listen to them and they ften complain that my voice is too low and sometimes too high clipped over modulated    aand my phone mic is known as broken mi a2 yeas the famous i dont hear anything  i rarely make phone calls but that complain that both recording with screen off and calls are to low..  mostly i notice the recorings because i dont have th it in my mouth i put it down and the wave beam is formed in an... .. etcetc  ... thats for another patch now

this was just warmpu. btw im listening to pearlman signal compression to fall asleep. got to chap 4 lz78 compression from anagram dictionaries...

so my big plan that i need is an opus encoder which is more advanceed than amr AND with volume boost that I HAVE NOW so far found anywhere   so maybe i will invent the wheel again. theere is one french dev that made it ut he is not responding  coincidentally i cycled by him outside in west france two years ago on a trek   never made the connection unitl later. .. anyway he has a clean aomplifier for the raw data up to 20 dB and encode it manually in opus... unfortunately he has also made the strange mistake to get stuck in liv and zivs books from 78   possibly amended by welch 79  LZW    .... mp3 was t  it was mp1 .. anyway it is now much later and opus i much more advanced than amr and ... i need to utilize that power with 16 or 12 kbit encoding.. possibly 16 is enough. he wont let me pass any settings to all the work he done to implement all the encoders in an android project..   its simply 8k cutoff. voce profile. libOPUS has a setting internal settings for voice in addition to manual cutoff. and of course one bit per sample or less. or fe  12 khz/12 kbit and down. i waould use 16/16. still i like one bit per sample. imagine how much heavby lifiting is done to get to that extremey sparse representation .... anyway back to pearlman and.. what els there was something els... right when i change the volume i have o use  aLUIT table since a linear volume gain is bad


so dont read any o that drivel above. just tell me WHERE IT IS the stuff i need to do. where is the android audio lib rec lib that can apply a good operational op OP-AMP to the ijmput .   the IDEAL op am... nv...

so i am looking for a recorder that applies a volume boost. that will be alot of coding but not difficult. just the tedium o f ordinary work

and secondly i will probably have to create myself that voice colume detector to automatically adjust the gain when i move around in my office and go over all the plates and have the phone stationary on record on the table